### PR TITLE
Passage des liens e-mail en mailto sur les pages de contribution

### DIFF
--- a/content/contribuer/_index.md
+++ b/content/contribuer/_index.md
@@ -9,7 +9,7 @@ type: docs
 
 Si vous souhaitez nous aider sur ce projet, n'hésites pas à nous contacter par e-mail :
 
-- [cloudducoeur@restosducoeur.org](cloudducoeur@restosducoeur.org)
+- [cloudducoeur@restosducoeur.org](mailto:cloudducoeur@restosducoeur.org)
 
 ## A cette documentation ?
 

--- a/content/doc/contribuer/_index.md
+++ b/content/doc/contribuer/_index.md
@@ -21,4 +21,4 @@ Pour contribuer à cette documentation, nous vous invitons à regarder cette doc
 
 Si vous souhaitez nous aider sur ce projet, n’hésites pas à nous contacter par e-mail :
 
-- [cloudducoeur@restosducoeur.org](cloudducoeur@restosducoeur.org)
+- [cloudducoeur@restosducoeur.org](mailto:cloudducoeur@restosducoeur.org)


### PR DESCRIPTION
Bonjour,

Je propose une petite modification sur quelques liens afin que les différents navigateurs comprennent qu'ils s'agit
d'un e-mail, et donc faire une redirection sur les boîtes mail par exemple. (plutôt que la page 404 actuelle)

En vous souhaitant bon courage pour la suite des différents projets 💪 
